### PR TITLE
Fix bug in JSON parser

### DIFF
--- a/R/metadata_functions.R
+++ b/R/metadata_functions.R
@@ -69,10 +69,10 @@ listCensusMetadata <- function(name, vintage=NULL, type="variables") {
 
 		# Manual fill with NAs as needed to avoid adding a dplyr::bind_rows or similar dependency
 		cols <- unique(unlist(lapply(raw$variables, names)))
-		cols <- cols[!(cols %in% c("predicateOnly", "datetime", "validValues"))]
+		cols <- cols[!(cols %in% c("predicateOnly", "datetime", "values"))]
 		makeDf <- function(d) {
-			if("validValues" %in% names(d)) {
-				d$validValues <- NULL
+			if("values" %in% names(d)) {
+				d$values <- NULL
 			}
 			df <- data.frame(d)
 			df[, setdiff(cols, names(df))] <- NA


### PR DESCRIPTION
I don't have an archived version of the old metadata file, but several of the columns called in listCensusMetadata no longer exist (including "datetime" and "validValues"). Took a guess and replaced references to "validValues" with "values" and everything seems to be working, at least for 1- and 5-year ACS.

I didn't mess with anything else (e.g., reference to "datetime" is still there) because I wasn't sure if this would inadvertently affect other APIs (after skimming other APIs, doesn't seem like it would).

Hope this helps!