### PR TITLE
Extra backtick in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Installation
 Get the latest stable release from CRAN: 
 ```R
-install.packages("censusapi")`
+install.packages("censusapi")
 ```
 
 You can also install the latest development version of `censusapi` from Github using `devtools`. Most people will not want to do this - BEWARE!:


### PR DESCRIPTION
See #60. Small typo in README. There's an extra backtick in the installation line.
Currently,
```
install.packages("censusapi")`
```
Should be,
```
install.packages("censusapi")`
```