### PR TITLE
Update getcensus_functions.R

### DIFF
--- a/R/getcensus_functions.R
+++ b/R/getcensus_functions.R
@@ -223,9 +223,7 @@ getCensus <-
 		vars <- split(vars, ceiling(seq_along(vars)/50))
 		get <- lapply(vars, function(x) paste(x, sep='', collapse=","))
 		data <- lapply(get, function(x) getFunction(apiurl, name, key, x, region, regionin, time, date, period, monthly, show_call, category_code, data_type_code, naics, pscode, naics2012, naics2007, naics2002, naics1997, sic, ...))
-		colnames <- unlist(lapply(data, names))
-		data <- do.call(cbind,data)
-		names(data) <- colnames
+		data <- Reduce(function(dtf1, dtf2) merge(dtf1, dtf2, all=TRUE, sort=FALSE), data)
 	} else {
 		get <- paste(vars, sep='', collapse=',')
 		data <- getFunction(apiurl, name, key, get, region, regionin, time, date, period, monthly, show_call, category_code, data_type_code, naics, pscode, naics2012, naics2007, naics2002, naics1997, sic, ...)


### PR DESCRIPTION
Attempt to fix issue #57 by merging rather than binding columns.

This works in my testing, but I don't know how to test it fully (never worked on an R package before and I mostly use the tidyverse so my Base R is rusty).

I think it does make some of the later code that removes duplicate columns superfluous because duplicated columns get used in the merge by default.  

This does mean that the order of variables isn't exactly preserved--any duplicates will be moved to the front of the line after the geography variables.  If there was an easy way to identify the geography variables in advance, I suppose you could merge based only on those, but any given census variable should be immutable, so including them in the merge shouldn't matter.

