### PR TITLE
Update getcensus_functions.R responseRaw string column parts

### DIFF
--- a/R/getcensus_functions.R
+++ b/R/getcensus_functions.R
@@ -55,7 +55,7 @@ getFunction <- function(apiurl, name, key, get, region, regionin, time, year, da
 		df[] <- lapply(df, as.character)
 
 		# Make columns numeric based on column names - unfortunately best strategy without additional API calls given structure of data across endpoints
-		string_col_parts <- "_TTL|_NAME|NAICS2012|NAICS2017|NAICS2012_TTL|NAICS2017_TTL|fage4|FAGE4|LABEL|_DESC|CAT"
+		string_col_parts <- "_TTL|_NAME|NAICS2012|NAICS2017|NAICS2012_TTL|NAICS2017_TTL|fage4|FAGE4|LABEL|_DESC|CAT|UNIT_QY|_FLAG"
 
 		# For ACS data, do not make columns numeric if they are ACS annotation variables - ending in MA or EA or SS
 		if (grepl("acs/acs", name, ignore.case = T)) {


### PR DESCRIPTION
Several variables in timeseries/intltrade/imports have numerals in their names, but are not numeric data. Adding "UNIT_QY" (a quantity unit of measure field) and "_FLAG" (a flag field) to string_col_parts account for these fields prevents NA from the numeric conversion.

See: https://api.census.gov/data/timeseries/intltrade/imports/hs/variables.html
