### PR TITLE
Add getCensusByState function

### DIFF
--- a/censusapi.Rproj
+++ b/censusapi.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
This pull request contains an idea for an additional function for easily gathering data for multiple states. The proposed function, getCensusByState, is a function where you can supply a vector of states and then retrieve data for each of them, with error handling to take care of the case where a state lacks data or there is some other error. It relies mostly on getCensus and simply automates the process for data retrieval from multiple states. Several examples are included to see how it works. 