### PR TITLE
Make API key optional

### DIFF
--- a/R/getcensus_functions.R
+++ b/R/getcensus_functions.R
@@ -149,6 +149,7 @@ getFunction <- function(apiurl, name, key, get, region, regionin, time, year, da
 #' the Census Bureau.
 #' @param key Your Census API key, obtained at https://api.census.gov/data/key_signup.html.
 #' This function will default to a `CENSUS_KEY` stored in your .Renviron if available.
+#' You can specify key as NULL. Census allows a limited number of requests with no API key.
 #' @param ... Other valid arguments to pass to the Census API. Note: the APIs are case sensitive.
 #' @keywords api
 #' @examples
@@ -245,9 +246,11 @@ getCensus <-
 	}
 
 	# Check for key in environment
-	key_env <- Sys.getenv("CENSUS_KEY")
-	if ((key_env == "" & key == key_env)) {
-		stop("'key' argument is missing. A Census API key is required and can be requested at https://api.census.gov/data/key_signup.html.\nPlease add your Census key to your .Renviron - see instructions at https://github.com/hrecht/censusapi#api-key-setup")
+	if (!is.null(key)){
+	  key_env <- Sys.getenv("CENSUS_KEY")
+	  if ((key_env == "" & key == key_env)) {
+	    stop("'key' argument is missing. A Census API key is required and can be requested at https://api.census.gov/data/key_signup.html.\nPlease add your Census key to your .Renviron - see instructions at https://github.com/hrecht/censusapi#api-key-setup")
+	  }
 	}
 
 	apiurl <- constructURL(name, vintage)

--- a/censusapi.Rproj
+++ b/censusapi.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/getCensus.Rd
+++ b/man/getCensus.Rd
@@ -37,7 +37,8 @@ or `acs/acs5`. See `listCensusApis()` for options.}
 \item{vintage}{Vintage (year) of dataset, e.g. 2014. Not required for timeseries APIs.}
 
 \item{key}{Your Census API key, obtained at https://api.census.gov/data/key_signup.html.
-This function will default to a `CENSUS_KEY` stored in your .Renviron if available.}
+This function will default to a `CENSUS_KEY` stored in your .Renviron if available.
+You can specify key as NULL. Census allows a limited number of requests with no API key.}
 
 \item{vars}{List of variables to get. Required.}
 


### PR DESCRIPTION
This addresses the feature request #87 

See example below with reprex. Reprex output slight modified to replacye my actual key with xxxxxxxxxx

``` r
# devtools::install_github("https://github.com/szimmer/censusapi/tree/allow-null-key")

library(censusapi)
#> 
#> Attaching package: 'censusapi'
#> The following object is masked from 'package:methods':
#> 
#>     getFunction
acs_simple_keyrenv <- getCensus(
  name = "acs/acs5",
  vintage = 2020,
  vars = c("NAME", "B01001_001E", "B19013_001E"),
  region = "place:*",
  regionin = "state:01",
  show_call = TRUE)
#> [1] "Your successful api call was:  https://api.census.gov/data/2020/acs/acs5?key=xxxxxxxxxx&get=NAME%2CB01001_001E%2CB19013_001E&for=place%3A%2A&in=state%3A01"
#> [1] "For more information, visit the documentation at https://www.hrecht.com/censusapi/"

acs_simple_nokey <- getCensus(
  name = "acs/acs5",
  vintage = 2020,
  vars = c("NAME", "B01001_001E", "B19013_001E"),
  region = "place:*",
  regionin = "state:01",
  key=NULL,
  show_call=TRUE)
#> [1] "Your successful api call was:  https://api.census.gov/data/2020/acs/acs5?get=NAME%2CB01001_001E%2CB19013_001E&for=place%3A%2A&in=state%3A01"
#> [1] "For more information, visit the documentation at https://www.hrecht.com/censusapi/"

identical(acs_simple_keyrenv, acs_simple_nokey)
#> [1] TRUE
```

<sup>Created on 2023-04-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.2 (2022-10-31 ucrt)
#>  os       Windows 10 x64 (build 22621)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  English_United States.utf8
#>  ctype    English_United States.utf8
#>  tz       America/New_York
#>  date     2023-04-09
#>  pandoc   2.19.2 @ C:/Program Files/RStudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  censusapi   * 0.8.0   2023-04-09 [1] Github (szimmer/censusapi@15b2b02)
#>  cli           3.4.1   2022-09-23 [1] CRAN (R 4.2.2)
#>  curl          5.0.0   2023-01-12 [1] CRAN (R 4.2.3)
#>  digest        0.6.29  2021-12-01 [1] CRAN (R 4.2.1)
#>  evaluate      0.16    2022-08-09 [1] CRAN (R 4.2.1)
#>  fansi         1.0.4   2023-01-22 [1] CRAN (R 4.2.2)
#>  fastmap       1.1.0   2021-01-25 [1] CRAN (R 4.2.1)
#>  fs            1.5.2   2021-12-08 [1] CRAN (R 4.2.1)
#>  glue          1.6.2   2022-02-24 [1] CRAN (R 4.2.1)
#>  highr         0.9     2021-04-16 [1] CRAN (R 4.2.1)
#>  htmltools     0.5.3   2022-07-18 [1] CRAN (R 4.2.1)
#>  httr          1.4.5   2023-02-24 [1] CRAN (R 4.2.3)
#>  jsonlite      1.8.4   2022-12-06 [1] CRAN (R 4.2.2)
#>  knitr         1.40    2022-08-24 [1] CRAN (R 4.2.1)
#>  lifecycle     1.0.3   2022-10-07 [1] CRAN (R 4.2.2)
#>  magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.2.1)
#>  pillar        1.8.1   2022-08-19 [1] CRAN (R 4.2.1)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.2.1)
#>  purrr         0.3.5   2022-10-06 [1] CRAN (R 4.2.1)
#>  R.cache       0.16.0  2022-07-21 [1] CRAN (R 4.2.1)
#>  R.methodsS3   1.8.2   2022-06-13 [1] CRAN (R 4.2.0)
#>  R.oo          1.25.0  2022-06-12 [1] CRAN (R 4.2.0)
#>  R.utils       2.12.0  2022-06-28 [1] CRAN (R 4.2.1)
#>  R6            2.5.1   2021-08-19 [1] CRAN (R 4.2.1)
#>  reprex        2.0.2   2022-08-17 [1] CRAN (R 4.2.1)
#>  rlang         1.1.0   2023-03-14 [1] CRAN (R 4.2.2)
#>  rmarkdown     2.16    2022-08-24 [1] CRAN (R 4.2.1)
#>  rstudioapi    0.13    2020-11-12 [1] CRAN (R 4.2.1)
#>  sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.2.1)
#>  stringi       1.7.8   2022-07-11 [1] CRAN (R 4.2.1)
#>  stringr       1.4.1   2022-08-20 [1] CRAN (R 4.2.1)
#>  styler        1.7.0   2022-03-13 [1] CRAN (R 4.2.1)
#>  tibble        3.2.0   2023-03-08 [1] CRAN (R 4.2.2)
#>  utf8          1.2.3   2023-01-31 [1] CRAN (R 4.2.2)
#>  vctrs         0.5.2   2023-01-23 [1] CRAN (R 4.2.2)
#>  withr         2.5.0   2022-03-03 [1] CRAN (R 4.2.1)
#>  xfun          0.32    2022-08-10 [1] CRAN (R 4.2.1)
#>  yaml          2.3.5   2022-02-21 [1] CRAN (R 4.2.1)
#> 
#>  [1] C:/Users/steph/AppData/Local/R/win-library/4.2
#>  [2] C:/Program Files/R/R-4.2.2/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
